### PR TITLE
Add policy related pages

### DIFF
--- a/content/pages/info/accessibility.md
+++ b/content/pages/info/accessibility.md
@@ -1,6 +1,5 @@
 ---
 title: Accessibility Statement
-slug: /accessibility/
 ---
 
 <h2>Need Help?</h2>

--- a/content/pages/info/code-of-conduct.md
+++ b/content/pages/info/code-of-conduct.md
@@ -1,6 +1,5 @@
 ---
 title: Conference Code of Conduct
-slug: /code-of-conduct/
 ---
 
 _This Code of Conduct is also available in [Dutch](http://nl.confcodeofconduct.com), [French](http://fr.confcodeofconduct.com), [German](http://de.confcodeofconduct.com), [Italian](http://it.confcodeofconduct.com), [Norwegian](http://no.confcodeofconduct.com), [Polish](http://pl.confcodeofconduct.com), [Portuguese(Brazil)](http://pt-br.confcodeofconduct.com), [Russian](http://ru.confcodeofconduct.com), [Spanish](http://es.confcodeofconduct.com), [Japanese](http://ja.confcodeofconduct.com), [Hebrew](http://he.confcodeofconduct.com), [Turkish](http://tr.confcodeofconduct.com/), [Traditional Chinese](http://tw.confcodeofconduct.com/)._

--- a/content/pages/info/diversity/ca.md
+++ b/content/pages/info/diversity/ca.md
@@ -1,0 +1,63 @@
+---
+title: Diversitat a RustFest
+---
+
+[English version](/info/diversity/)
+
+[Ver en español](/info/diversity/es/)
+
+
+## Scholarship applications now open!
+<a class="button primary" href="/scholarships/ca">Apply for Scholarship Support</a>
+
+RustFest és una de les conferències més grans sobre el llenguatge de programació Rust i es pren de debò la missió de mantenir una comunitat inclusiva. 
+
+Aquesta es basa en quatre principis.
+
+## Pressupostem tenint en compte a les persones
+
+RustFest té l'objectiu d'oferir entrades a baix cost sense renunciar a ser un esdeveniment de qualitat. És una de les conferències més veteranes i assequibles sobre Rust, amb entrades al voltant dels 100 euros i d'altres específiques a preu més assequible. El cost de l'entrada està centrat en un únic principi: que RustFest es pugui celebrar encara que no hi hagin patrocinadors.
+
+Encara que no sempre està garantit, històricament hem sufragat totes les despeses als nostres ponents i organitzadors per a fer possible la seva assistència al RustFest. En tot cas, sempre cobrim totes les despeses a qui no s'ho pot permetre.
+
+Quan hi ha excedent econòmic, sovint s'inverteix en la comunitat o en la següent edició de RustFest.
+
+## Esforços en l'atenció a la diversitat
+
+Les últimes edicions de RustFest han tingut una considerable quantitat d'entrades enfocades a l'atenció a diversitat (5%). En contraposició a altres conferències, hem pagat totes les despeses de viatge i allotjament per al primer lot d'entrades. Això inclou viatges transcontinentals. D'altra banda, de ser necessari, paguem amb anticipació les despeses del viatge als posseïdors d'entrades de diversitat.
+
+Per a nosaltres, és molt important que les persones que adquireixen entrades enfocades a l'atenció de la diversitat no tinguin cap problema per a poder assistir. Per a una conferència amb el nostre rang de preu, el cost del viatge és, sovint, més prohibitiu que el de les entrades.
+
+## Diversitat inclou discapacitat
+
+Quan parlem de diversitat en les tecnologies de la informació, la discapacitat és sovint oblidada i creiem que això ha de canviar. RustFest ha tingut sempre una [declaració d'accesibilitat](/accessibility/) amb tota la documentació necessària per endavant. Els nostres esforços estan revisats i implementats per persones amb discapacitats. RustFest sempre disposa d'una persona responsable de vetllar per l'accessibilitat.
+
+RustFest reconeix que la discapacitat és diversitat i, si ho necessites, treballarà directament per a solucionar totes les teves necessitats. Treballarem activament amb tu per a resoldre qualsevol assumpte.
+
+## Comida y catering adaptado
+
+Sempre assegurem que els serveis de catering serveixin menjar apropiat per a vegetarians, vegans i també menjar especial sota demanda. També treballem per cobrir qualsevol necessitat dietètica. Si és possible, busquem serveis de menjar que puguin satisfer totes aquestes opcions ja que hem vist que és la manera més fàcil d'oferir menjar de qualitat a gran escala per a tothom.
+Les sol·licituds es gestionen amb atenció i, fins al moment, només hem tingut cap petició que no poguéssim satisfer.
+
+Si us plau, tingues en compte que pel fet que RustFest és una conferència que es realitza cada vegada en una zona geogràfica diferent, treballem amb diferents càterings, per la qual cosa això pot introduir variacions d'una edició a una altra.
+
+## Res d'alcohol en el pressupost
+
+RustFest té una regla estricta: no es serveix alcohol de forma gratuïta. Això inclou rebutjar ofertes de certs patrocinadors. Hem vist en conferències prèvies que oferir alcohol gratuïtament contribueix a una cultura de festivitat agressiva, ja que la gent acaba bevent gratuïtament i comprant més alcohol.
+
+Tingues en compte que als voltants d'alguns centres de la conferència és possible trobar alcohol a la venda, però sempre verifiquem que hi ha disponibles opcions no alcohòliques de qualitat i econòmiques i bastant espai per evitar trobar-se amb gent embriagada.
+
+
+## Sense debats
+
+Tenim processos per a gestionar moltes coses que suposen petits reptes per a nosaltres, però grans solucions per a tu.
+
+Quan facis una petició, no exigim cap mena de prova i sempre assumim que actues de bona fe. RustFest serveix per passar una bona estona i si tens algun tipus de necessitat, t'ajudarem de la millor manera possible.
+
+Confiem en tu i, fins ara, hem tingut una formidable experiència actuant d'aquesta manera.
+
+## Ens esforcem per millorar constantment
+
+La comunitat de Rust és jove i RustFest també és un projecte jove. Estarem encantats de rebre qualsevol suggeriment sobre RustFest en qualsevol moment. Si us plau, contacta amb nosaltres a través de [team@rustfest.eu](mailto:team@rustfest.eu).
+
+Si creus que podem millorar qualsevol cosa, si us plau, fes-nos-ho saber i ens hi ocuparem!. Si volguessis col·laborar, si us plau no dubtis a contactar amb nosaltres per a fer-nos saber que vols formar part de l'equip. Sabem que les propostes no són sempre gratuïtes i, per tant, intentarem dedicar esforços i part del pressupost, en la mesura que sigui possible, a la teva proposta.

--- a/content/pages/info/diversity/es.md
+++ b/content/pages/info/diversity/es.md
@@ -1,0 +1,62 @@
+---
+title: Diversidad en RustFest
+---
+
+[English version](/info/diversity/)
+
+[Veure en català](/info/diversity/ca)
+
+
+## Scholarship applications now open!
+<a class="button primary" href="/scholarships/es">Apply for Scholarship Support</a>
+
+RustFest es una de las conferencias más grandes sobre Rust y se toma en serio la misión de Rust de mantener una comunidad inclusiva. 
+Ésta se basa en cuatro principios.
+
+## Presupuestamos teniendo en cuenta a las personas
+
+RustFest tiene el objetivo de ofrecer entradas a bajo coste sin renunciar a una conferencia de calidad. Es una de las conferencias más veteranas y asequibles sobre Rust, con entradas alrededor de los 100 euros y otras a precio rebajado. El precio de la entrada está centrado en un único principio: que RustFest se pueda celebrar aunque no hayan patrocinadores.
+
+Aunque no siempre está garantizado, históricamente, hemos sufragado siempre todos los gastos a nuestros ponentes y organizadores para hacer posible su asistencia al RustFest. En todo caso, siempre pagamos todos los gastos a quien no puede permitírselo.
+
+El excedente económico, si hubiere, es a menudo invertido en la comunidad o guardado para la siguiente edición.
+
+## Esfuerzos en diversidad por encima de la media
+
+Las últimas ediciones del RustFest han tenido una considerable cantidad de entradas de diversidad (5%). En contraposición a otras conferencias, hemos pagado todos los gastos de viaje y alojamiento para el primer lote de entradas. Esto incluye viajes transcontinentales. Por otro lado, de ser necesario, pagamos por anticipado los gastos del viaje a los poseedores de entradas de diversidad.
+
+Para nosotros, es muy importante que éstos no tengan ningún problema para poder asistir. Para una conferencia de nuestro rango de precio, el precio del viaje es, a menudo, más prohibitivo que el de las entradas.
+
+## Diversidad incluye discapacidad
+
+Cuando hablamos de esfuerzo en diversidad de las TI, la discapacidad es a menudo olvidada, por lo que creemos que esto ha de cambiar. RustFest ha tenido siempre una [declaración de accesibilidad](/accessibility/) con la documentación adecuada  por adelantado. Nuestros esfuerzos están asesorados e implementados por personas discapacitadas. RustFest siempre dispone de una persona responsable de velar por la accesibilidad.
+
+RustFest reconoce que la discapacidad es diversidad y trabajará directamente contigo para solucionar todas tus necesidades. Junto a ti, trabajaremos activamente para resolver cualquier asunto.
+
+## Comida y opciones de servicios de comida
+
+Siempre aseguramos que los servicios de comida escogidos puedan servir comida apropiada para vegetarianos, veganos y también comida especial bajo demanda. También intentamos que pueda servirse comida para personas con otras necesidades dietéticas. Si es posible, buscamos servicios de comida que puedan satisfacer todas estas opciones ya que hemos visto que es la manera más fácil de ofrecer comida de calidad a gran escala para todo el mundo.
+
+Las solicitudes se gestionan diligentemente y, hasta el momento, solo hemos tenido una petición que no hemos podido satisfacer.
+
+Por favor, ten en cuenta que debido a que RustFest es una conferencia que se realiza cada vez en una zona geográfica distinta, solo podemos trabajar con un servicio de comida una vez, por lo que esto puede introducir variaciones de una edición a otra.
+
+## Ningún presupuesto destinado a alcohol
+
+RustFest tiene una regla estricta: no se sirve alcohol de manera gratuita. Esto incluye rechazar ofertas de ciertos patrocinadores. Hemos visto en conferencias previas que ofrecer alcohol gratuito contribuye a una cultura de festividad agresiva, ya que la gente acaba bebiendo gratuitamente y comprando más alcohol.
+
+Ten en cuenta que en los alrededores de algunos centros de la conferencia es posible encontrar alcohol a la venta, pero siempre verificamos que hay disponibles opciones no alcohólicas de calidad y económicas y bastante espacio para evitar encontrarse con gente embriagada. 
+
+## Sin debates
+
+Tenemos procesos para gestionar muchas cosas que suponen pequeños problemas para nosotros, pero grandes para ti.
+
+No exigimos ningún tipo de prueba y siempre asumimos que tus peticiones son de buena fe. RustFest está aquí para que pases un buen rato y si tienes algún tipo de necesidad, te ayudaremos de la mejor manera posible.
+
+Confiamos en ti y hasta ahora hemos tenido una formidable experiencia actuando de esta manera.
+
+## Nos esforzamos por mejorar constantemente
+
+La comunidad de Rust es joven y RustFest también es un proyecto joven. Estaremos encantados de recibir cualquier sugerencia sobre (éste y previos) RustFest en cualquier momento. Por favor, contacta con nosotros a través de [team@rustfest.eu](mailto:team@rustfest.eu).
+
+Si crees que podemos mejorar cualquier cosa, ¡por favor, háznoslo saber! Nos ocuparemos de ello. Si quisieras colaborar, por favor no dudes en contactar con nosotros para hacernos saber que quieres formar parte del equipo. Sabemos que las soluciones no son siempre gratuitas y, por tanto, intentaremos dedicar esfuerzos y parte del presupuesto, en la medida de lo posible, a tu tarea.

--- a/content/pages/info/diversity/index.md
+++ b/content/pages/info/diversity/index.md
@@ -1,0 +1,60 @@
+---
+title: Diversity at RustFest
+---
+
+[Ver en español](/info/diversity/es/)
+
+[Veure en català](/info/diversity/ca/)
+
+## Scholarship applications now open!
+<a class="button primary" href="/scholarships/">Apply for Scholarship Support</a>
+
+RustFest is one of the biggest Rust conferences and takes Rust's mission for an inclusive community seriously. This is based on multiple pillars.
+
+## People-first budgeting
+
+RustFest aims to have a low ticket price, while maintaining a good quality of the conference. We're the most affordable and longest Rust conference, with our ticket price fixed around 100 Euros and rebated tickets available. The ticket price is focused around a single principle: If RustFest had no sponsors, it would still happen.
+
+Although not always guaranteed, historically, we paid the full expenses of our speakers and organisers to attend the last RustFests. We always pay in full for people who can't afford otherwise.
+
+Budget overages are often invested into community efforts or kept around for the next edition.
+
+## Above-average diversity efforts
+
+The last RustFests have had a sizable amount of diversity tickets (5%). In contrast to many other conferences, we started to pay full travel and hotel lodging for the first set of tickets. This includes intercontinental travel. On request, we pre-pay the travel for diversity ticket holders.
+
+It is important to us that diversity ticket holders have no issues attending. For a conference of our price range, travel is often more prohibitive than tickets.
+
+## Diversity includes disability
+
+When talking about diversity efforts in IT, disability is often forgotten. We believe this needs to change. RustFest has always had an [accessibility statement](/accessibility/) with proper, upfront documentation. Our efforts are cross-checked and implemented with actually disabled people. RustFest always has a person responsible for accessibility efforts.
+
+RustFest acknowledges that disability is diverse and will work with you actively to meet all of your needs. 
+
+## Food and catering choices
+
+We always ensure our caterers can serve proper vegetarian and vegan meals and can cater to special requests. We also try to cater to other dietary needs. If possible, we search for catering that is built around these options, as we found it the easiest way to provide a good quality to all at scale.
+
+Requests are handled quickly and we up to now only had one request we couldn't serve.
+
+Please note that due to RustFest being a travelling conference, we can only ever work with a caterer once, which still leaves an element of variance.
+
+## No alcohol on conference budget
+
+RustFest has a strict rule around free alcohol: there is none. This includes refusing offers from sponsors for some. We found during previous conferences that offering free alcohol contributes to an aggressive party culture, as people would drink for free and _then_ buy some more.
+
+Please note that some fringe events of the conference may have alcohol on sale, but we check that there's always affordable and good non-alcoholic options available, and enough space to avoid drunk people.
+
+## No debates
+
+We have processes for dealing with a lot of things that are tiny issues for us, but big ones for you.
+
+We don't ask for proof and always assume good intentions when approaching us with a request. RustFest is here for _you_ to have a good time, and if you have any kind of need, we'll do our best to help you.
+
+We trust you and so far had a great experience with that.
+
+## We strive for constant improvement
+
+The Rust community is young and RustFest is a young project. We're happy to take any feedback about (this and previous) RustFests at any time. Please contact us at [team@rustfest.eu](mailto:team@rustfest.eu) around that.
+
+If you see something that can be improved, please let us know! We will care about it. If it happens to be a thing that you _like_ working on, please also approach us for becoming part of the team. We appreciate that solutions are not always for free and will always try to provide effort as well as a budget for your task.

--- a/content/pages/info/foss.md
+++ b/content/pages/info/foss.md
@@ -1,0 +1,15 @@
+---
+title: FOSS at RustFest
+---
+
+## Grants
+
+We give out travel and attendance grants to FOSS contributors. These often take the form of tickets and travel grants. Usually, these take the form of a campaign, such as the [libz blitz grant](https://blog.rustfest.eu/libz-blitz). We also assist project contributors to come to RustFest in other ways, for example by finding sponsors for them.
+
+## impl days
+
+After RustFest, there's usually `impl days`. Kicked off as an idea from the Rust project, we meet after the conference for usually 2 days in the form of a large hackfest. `impl days` are usually smaller than the conference and happen at other venues, but spawn new projects or learning experiences!
+
+## RustFest is an open project
+
+Anyone can express interest to join, and especially: all our material is free and can be used from our [online repository](https://github.com/rustfesteu). This especially applies to all text and writing on our websites, outside of personal pictures and bios.

--- a/content/pages/info/index.md
+++ b/content/pages/info/index.md
@@ -1,0 +1,23 @@
+---
+title: Information & Policies
+---
+
+## Policies
+
+RustFest documents all their policies openly. They can be found here:
+
+* [One-pager for Accessibility, Awareness & Policies](/info/policies)
+* [Accessibility](/info/accessibility)
+* [Code of Conduct](/info/code-of-conduct)
+    * We follow the PyCon [Attendee](https://us.pycon.org/2018/about/code-of-conduct/attendee-procedure/) and [Staff](https://us.pycon.org/2018/about/code-of-conduct/staff-procedure/) procedure for reporting
+* [Parents and nursing mothers](/info/parents)
+* [Call for Proposals submission and reimbursement policies](https://cfp.rustfest.eu/events/rustfest-barcelona-2019)
+    * [Our Program committee](/info/cfp-committee)
+* [Diversity tickets and conditions](https://diversitytickets.org)
+
+Please [mail us](mailto:team@rustfest.eu) if anything is unclear.
+
+## Info
+
+* [Diversity at RustFest](/info/diversity)
+* [FOSS at RustFest](/info/foss)

--- a/content/pages/info/parents.md
+++ b/content/pages/info/parents.md
@@ -1,0 +1,13 @@
+---
+title: Little Rustaceans
+---
+
+Like in the sea the older ones should care for the little ones. With that in mind, we provide child care for our conference attendees. We cater to any needs, but need to know a bit about your kid!
+
+If you would like to bring your kid, [contact us](mailto:team@rustfest.eu?subject=Child%20care%20in%20Barcelona) before 2018-10-25 so we can plan for child care. Requests after that time cannot be guaranteed, but still get in touch. Please include:
+
+* Their age
+* Their spoken languages
+* Any special things we need to be aware of (e.g. allergies, illnesses, food preferences, but only to the extend the caregiver needs to know)
+
+Watch this space and our [blog](https://blog.rustfest.eu) for further info.

--- a/content/pages/info/policies.md
+++ b/content/pages/info/policies.md
@@ -1,0 +1,65 @@
+---
+title: Accessibility, Awareness & Policies
+---
+
+<h2>Need Help?</h2>
+
+<address>
+Mail: <a href="mailto:team@rustfest.eu">team@rustfest.eu</a>
+</address>
+
+---
+
+**Catering and Sustainability**
+
+We’re providing water throughout the day as well as coffee and tea during the breaks. Feel free to bring your own drinking cup / bottle to avoid single-use items, if you have the possibility. Lunch will be served on both days at the venue as well as snacks provided during the short breaks (vegetarian and vegan options available). We are working together with the catering to make sure your dietary requirements are met.
+
+**Code of Conduct and Contact information**
+
+At RustFest we strive to make the conference as accessible, inclusive and save as possible. In order to ensure this, the event takes place under a [Code of Conduct](/code-of-conduct), and we follow the PyCon [Attendee](https://us.pycon.org/2018/about/code-of-conduct/attendee-procedure/) and [Staff](https://us.pycon.org/2018/about/code-of-conduct/staff-procedure/) procedure for reporting. If you haven’t read it yet, please do so before the conference. If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a conference organizer or a member of the awareness team (recognizable by their pink t-shirts) as soon as possible. You can find an overview of the organizers on the about page - feel free to approach us at the conference. Additionally, we are available to help community members engage with local law enforcement or to otherwise help those experiencing unacceptable behavior feel safe. In the context of in-person events, organizers will also provide escorts as desired by the person experiencing distress.
+
+In case of any emergency or Code of Conduct violation, contact any staff or accessibility team member immediately or contact us via e-mail or phone directly, we are always there for you:
+
+<address>
+Mail: <a href="mailto:coc@rustfest.eu">coc@rustfest.eu</a>
+</address>
+
+<br>
+
+**Scent and smoking policy**
+
+People with multiple chemical sensitivities, asthma, allergies, or other immune problems can experience serious and debilitating physical and neurological symptoms when exposed to the chemicals used in most scented products. Reactions can include sneezing and severe headaches and force people to leave the conference. While we don’t ask attendees to be fragrance-free, we do ask that you avoid wearing significant amounts of fragrance (e.g. don’t wear perfume that day). Keep in mind that laundry detergent, clothes softener, soap, body wash, deodorant, shampoo, conditioner, lotion, hair products, cologne and perfume may all have fragrances that can affect people with these sensitivities. If someone is wearing a scent that is causing you symptoms, please let a RustFest team member or the awareness team know and we will work with the person wearing it to reduce the scent. Please do not smoke near entryways and other common areas. If you smoke during breaks at the conference, please be sensitive to others and wash your hands after you smoke.
+
+**Pronoun stickers**
+
+This year we will again provide pronoun stickers that non-verbally show by which pronoun people want to be addressed - **they/them**, **she/her**, **he/his** or blank ones for you to write on. By this we can avoid misgendering each other, because you can’t know someone’s pronoun unless they’ve told you. The stickers will be placed on the welcome desk during registration and after - feel free to use them and put them on a visible spot on your clothing or elsewhere.
+
+**Color Communication Badges**
+
+Have you already heard about Color Communication Badges? We will be providing them for the very first time during registration and after. This resource is stemming from the autistic community and allows you to communicate your conversation preferences non-verbally. According to the guideline written by The Autistic Self Advocacy Network (ASAN), it works like this:
+
+Showing a **green badge** means that the person is actively seeking communication; they have trouble initiating conversations, but want to be approached by people who are interested in talking.
+
+Showing a **yellow badge** means that the person only wants to talk to people they recognize, not by strangers or people they only know from the Internet. The badge-wearer might approach strangers to talk, and that is okay; the approached people are welcome to talk back to them in that case. But unless you have already met the person face-to-face, you should not approach them to talk.
+
+Showing a **red badge** means that the person probably does not want to talk to anyone, or only wants to talk to a few people. The person might approach others to talk, and that is okay; the approached people are welcome to talk back to them in that case. But unless you have been told already by the badge-wearer that you are on their “red list”, you should not approach them to talk.
+
+[Read the complete ASAN guideline online.](https://autisticadvocacy.org/wp-content/uploads/2014/02/ColorCommunicationBadges.pdf)
+
+**Photography**
+
+On Saturday and Sunday there will be a professional photographer on site who will capture the conference’s best moments. We will have once more two kinds of lanyards: **Black ones** if you are ok with being photographed, and **red ones** if you do not wish so. We will inform the photographer to be considerate of this policy.
+
+**Gender-neutral toilets**
+
+On the main conference days Saturday and Sunday there will be gender-neutral toilets available, which means that everybody can use any of the toilets in the venue. Unfortunately we can’t provide this for the impl days because regular university classes will start again that day and the university policies don’t allow us to.
+Apart from this, there will be a selection of toiletries available in the bathrooms for you to use. If toilet paper or soap should run out, or if there should be any other problem with the toilet, please let us know so we can take care of it!
+
+**Quiet room / Nursing room**
+
+There will be a quiet room available that you are welcome to use if you need some quiet space away from the noise.
+You can work, think, chill out or nap in the quiet room but please don’t talk to other attendees. You can listen to headphones and you are also welcome to use computers and phones if they have their sound muted and you don’t have a voice conversation through them. If you and someone else in the quiet room want to chat, please leave the room. If others are talking or making noise in the quiet room, and you are comfortable reminding them of the rules, please do so. Otherwise please ask the registration desk for help. The room can also be used for nursing.
+
+**Live transcription**
+
+During the talks there will be a live captioning made visible on the screens, to make it easier for you to follow the speakers.

--- a/src/components/organisems/Header.js
+++ b/src/components/organisems/Header.js
@@ -77,6 +77,7 @@ export default function Header({ siteTitle, isFront }) {
         </HeaderLink>
         <NavBar>
           <HeaderLink to="/about">About</HeaderLink>
+          <HeaderLink to="/info">Info</HeaderLink>
           <CallToAction href="https://cfp.rustfest.eu">Submit a talk</CallToAction>
         </NavBar>
       </HeaderContainer>

--- a/src/components/templates/Page.js
+++ b/src/components/templates/Page.js
@@ -1,7 +1,22 @@
 import React from 'react';
+import styled from 'styled-components';
 import { graphql } from 'gatsby';
 import Layout from '../Layout';
 import SEO from '../Seo';
+
+/**
+ * Prevent paragraphs in list items with nested lists.
+ *
+ * See https://github.com/gatsbyjs/gatsby/issues/10870
+ */
+const ContentDiv = styled.div`
+  li > p {
+    font-size: inherit;
+    line-height: inherit;
+    max-width: initial;
+    margin: 0;
+  }
+`;
 
 export default ({ data }) => {
   const { page } = data;
@@ -13,7 +28,7 @@ export default ({ data }) => {
       />
       <article>
         <h1>{page.frontmatter.title}</h1>
-        <div dangerouslySetInnerHTML={{ __html: page.html }} />
+        <ContentDiv dangerouslySetInnerHTML={{ __html: page.html }} />
       </article>
     </Layout>
   );

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -59,7 +59,7 @@ export default function About(props) {
       <SEO title={'About'} />
       <h1>About</h1>
       <p>RustFest is Europe’s Rust-dedicated conference. The next edition of RustFest will take place as a two-day event in the Netherlands.</p>
-      <p>We care about diversity and accessibility at this conference – please take a look at our <Link to={"/codeofconduct"}>Code of Conduct</Link> and <Link to={"/accessibility"}>Accessibility Statement</Link>.</p>
+      <p>We care about diversity and accessibility at this conference – please take a look at our <Link to={"/info/code-of-conduct"}>Code of Conduct</Link> and <Link to={"/info/accessibility"}>Accessibility Statement</Link>.</p>
       <h2>Team</h2>
       <TeamGrid>
         {teammembers}


### PR DESCRIPTION
This commit also removes the `slug` field from the pages MarkDown files
because the file path and name is already used for the path.

Closes #5 

Some follow-ups

- Need to check links to CFP process website
- Need to fix the CFP Committee
- The diversitytickets.org website’s SSL certificate has expired, we link there
- The scholarships page is not yet created (but linked to on the diversity pages)

Reopened #19 because the branch that was made against was deleted. This PR is a draft because it needs work depending on the venue/location.