### PR TITLE
Add build and deploy GitHub action

### DIFF
--- a/.github/workflows/gatsby-build.yaml
+++ b/.github/workflows/gatsby-build.yaml
@@ -1,0 +1,17 @@
+name: Build and Deploy
+on: 
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Gatsby Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+      - run: yarn install
+      - run: yarn deploy

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![](https://github.com/RustFestEU/netherlands.rustfest.eu/workflows/Build%20and%20Deploy/badge.svg)
+
 # Contributing
 
 If you want to add to this website use git to clone it.


### PR DESCRIPTION
This adds a GitHub action that should automatically install all
dependencies using Node.js 14.x and then run the `deploy` yarn command.

`yarn deploy` has previously been used to build and push to the
`gh-pages` branch which powers the live website.

This should ensure that any pull requests merged to `master` are
automatically deployed.